### PR TITLE
1.0.15: Reorganize some Dockerfile instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ WORKDIR /
 RUN rm -rf /tmp/strelka*
 
 #strelka requires a couple steps to run, so add a helper script to sequence those
-ADD docker_helper.sh /usr/bin/
+COPY docker_helper.sh /usr/bin/
 ENTRYPOINT ["/usr/bin/docker_helper.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ LABEL \
   version="1.0.15" \
   description="Strelka image for use in Workflows"
 
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
   bzip2 \
   g++ \
   make \
@@ -19,12 +18,12 @@ RUN apt-get install -y \
 ENV STRELKA_INSTALL_DIR /opt/strelka
 
 WORKDIR /tmp
-RUN wget ftp://strelka:%27%27@ftp.illumina.com/v1-branch/v1.0.15/strelka_workflow-1.0.15.tar.gz
-RUN tar -xzf strelka_workflow-1.0.15.tar.gz
+RUN wget ftp://strelka:%27%27@ftp.illumina.com/v1-branch/v1.0.15/strelka_workflow-1.0.15.tar.gz && \
+  tar -xzf strelka_workflow-1.0.15.tar.gz
 
 WORKDIR /tmp/strelka_workflow-1.0.15
-RUN ./configure --prefix=$STRELKA_INSTALL_DIR
-RUN make
+RUN ./configure --prefix=$STRELKA_INSTALL_DIR && \
+  make
 
 WORKDIR /
 RUN rm -rf /tmp/strelka*


### PR DESCRIPTION
These changes take under advisement the [Dockerfile Best Practices document](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/) by combining related `RUN` statements (especially `apt-get` commands) to reduce layering and by avoiding the use of `ADD`.
